### PR TITLE
Add .saveIfNotExists()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ keyHolder.remove("my-key");
 
 ### Methods
 
-Note: All save methods will overwrite old keys if they exist, this behaviour will be tweaked in the future. Please use `.update()` for updating keys.
-
 | Name                 | Description                                          | Arguments                                               | Return             |
 |----------------------|------------------------------------------------------|---------------------------------------------------------|--------------------|
 | #.read()             | Read a key from the keyholder                        | `key: string`                                           | `string | null`    |
@@ -58,6 +56,7 @@ Note: All save methods will overwrite old keys if they exist, this behaviour wil
 | #.save()             | Save a key to the keyholder                          | `TKeyData`                                              | `void`             |
 | #.saveBulk()         | Save multiple keys to the keyholder                  | `keys: TKeyData[]`                                      | `Promise<void>`    |
 | #.saveBulkFromFile() | Save multiple keys from a JSON file to the keyholder | `filePath: string`                                      | `Promise<unknown>` |
+| #.saveIfNotExists()  | Saves a key to the keyholder if it doesn't exist     | `TKeyData`                                              | `void`             |
 | #.update()           | Updates a key in the keyholder if it exists          | `TKeyData`                                              | `void`             |
 | #.dump()             | Dump all the keys in the keyholder to a file         | `filePath: string`                                      | `Promise<unknown>` |
 | #.remove()           | Remove a key from the keyholder                      | `key: string`                                           | `void`             |

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -107,6 +107,17 @@ export class KeyHolder implements IKeyStore {
 		return promise;
 	};
 
+	/** 
+	 * Saves a key-value pair if it doesn't exist, will throw an error if the key already exists.
+	*/
+	saveIfNotExists = ({ key, value, hashed }: TKeyData) => {
+		if (!this.storedData[key]) {
+			this.save({ key, value, hashed });
+		} else {
+			throw new Error(`Key ${key} already exists.`);
+		}
+	};
+
 
 	/** 
 	 * Updates a key-value pair in the store if it exists, if it doesn't throw an error.

--- a/lib/tests/package.test.ts
+++ b/lib/tests/package.test.ts
@@ -53,6 +53,20 @@ test('Can update a key-value pair', () => {
 });
 
 
+// Can save a value without overwriting an existing value
+test('Can save a value without overwriting an existing value', () => {
+	const keyHolder = new KeyHolder();
+
+	keyHolder.saveIfNotExists({ key: testKey, value: testValue });
+	expect(keyHolder.read(testKey)).toBe(testValue);
+
+	// try to save a value with the same key and pass if it throws an error
+	expect(() => {
+		keyHolder.saveIfNotExists({ key: testKey, value: 'updated-value' });
+	}).toThrowError();
+});
+
+
 // Can read all key-value pairs from the store
 test('Can read all key-value pairs from the store', () => {
 	const keyHolder = new KeyHolder({ data:[

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -9,6 +9,8 @@ export interface IKeyStore {
   saveBulk(data: TKeyData[]): Promise<void>
 
   saveBulkFromFile(filePath: string): Promise<unknown>
+  
+  saveIfNotExists({ key, value, hashed }: TKeyData): void
 
   update({ key, value, hashed }: TKeyData): void
 


### PR DESCRIPTION
### Changes
<!-- Describe your commits and what they change. -->
Adds the `.saveIfNotExists()` method to prevent overwriting existing values. This is more of a placeholder feature until v1 when all behaviour will be overhauled with `.save` to prevent overwriting by default without a flag.
  
<!-- If this pull request is related to any issues, please tag them below. -->

  
#### Licensing
<!-- Make sure you check both of these, otherwise your work might not be merged. -->
- [x] I agree to license my work under the repository LICENSE.
