### PR TITLE
Add Overwrite to Save

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run jest
+yarn run build && yarn run lint && yarn run jest

--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ keyHolder.remove("my-key");
 | TKeyData          | `{ key: string, value: string \|object, hashed: boolean }` |
 | TKeyStoreSettings | `{ hashedByDefault?: boolean }`                            |
 | TKeyStoreInit     | `{ settings?: TKeyStoreSettings, data?: TKeyData[] }`      |
+| TSaveSettings     | `{ settings?: overwrite?: boolean }`                       |

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ keyHolder.remove("my-key");
 
 ### Methods
 
-Note: All save methods will overwrite old keys if they exist, this behaviour will be tweaked in the future. Please use `.update()` for updating keys.
-
 | Name                 | Description                                          | Arguments                                               | Return             |
 |----------------------|------------------------------------------------------|---------------------------------------------------------|--------------------|
 | #.read()             | Read a key from the keyholder                        | `key: string`                                           | `string | null`    |
@@ -58,6 +56,7 @@ Note: All save methods will overwrite old keys if they exist, this behaviour wil
 | #.save()             | Save a key to the keyholder                          | `TKeyData`                                              | `void`             |
 | #.saveBulk()         | Save multiple keys to the keyholder                  | `keys: TKeyData[]`                                      | `Promise<void>`    |
 | #.saveBulkFromFile() | Save multiple keys from a JSON file to the keyholder | `filePath: string`                                      | `Promise<unknown>` |
+| #.saveIfNotExists()  | Saves a key to the keyholder if it doesn't exist     | `TKeyData`                                              | `void`             |
 | #.update()           | Updates a key in the keyholder if it exists          | `TKeyData`                                              | `void`             |
 | #.dump()             | Dump all the keys in the keyholder to a file         | `filePath: string`                                      | `Promise<unknown>` |
 | #.remove()           | Remove a key from the keyholder                      | `key: string`                                           | `void`             |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const keyHolder = new KeyHolder();
 keyHolder.save({key: "my-key", value: "This is a value for a key"});
 
 // Get the value of a key
-keyHolder.read("my-key"); // "This is a value for a key"
+keyHolder.read("my-key")?.value; // "This is a value for a key"
 
 // Remove a key from the KeyHolder
 keyHolder.remove("my-key");
@@ -53,11 +53,11 @@ keyHolder.remove("my-key");
 |----------------------|------------------------------------------------------|---------------------------------------------------------|--------------------|
 | #.read()             | Read a key from the keyholder                        | `key: string`                                           | `string | null`    |
 | #.readAll()          | Read all keys from the keyholder,                    | `none`                                                  | `TKeyData[]`       |
-| #.save()             | Save a key to the keyholder                          | `TKeyData`                                              | `void`             |
-| #.saveBulk()         | Save multiple keys to the keyholder                  | `keys: TKeyData[]`                                      | `Promise<void>`    |
+| #.save()             | Save a key to the keyholder                          | `TKeyData, TSaveSettings`                               | `void`             |
+| #.saveBulk()         | Save multiple keys to the keyholder                  | `TKeyData[], TSaveSettings`                             | `Promise<void>`    |
 | #.saveBulkFromFile() | Save multiple keys from a JSON file to the keyholder | `filePath: string`                                      | `Promise<unknown>` |
 | #.saveIfNotExists()  | Saves a key to the keyholder if it doesn't exist     | `TKeyData`                                              | `void`             |
-| #.update()           | Updates a key in the keyholder if it exists          | `TKeyData`                                              | `void`             |
+| #.update()           | DEPRECATED: Update a value if it exists              | `TKeyData`                                              | `void`             |
 | #.dump()             | Dump all the keys in the keyholder to a file         | `filePath: string`                                      | `Promise<unknown>` |
 | #.remove()           | Remove a key from the keyholder                      | `key: string`                                           | `void`             |
 | #.removeBulk()       | Remove multiple keys from the keyholder              | `keys: string[]`                                        | `Promise<void>`    |

--- a/lib/tests/package.test.ts
+++ b/lib/tests/package.test.ts
@@ -19,7 +19,7 @@ test('Can initialise a KeyHolder with data', () => {
 	]});
 
 	expect(keyHolder).toBeDefined();
-	expect(keyHolder.read(testKey)).toBe(testValue);
+	expect(keyHolder.read(testKey)?.value).toBe(testValue);
 });
 
 
@@ -32,24 +32,8 @@ test('Can initialise a KeyHolder as hashed', () => {
 	keyHolder.save({ key: testKey, value: testValue });
 
 	expect(keyHolder).toBeDefined();
-	expect(keyHolder.read(testKey)).not.toBe(testValue);
+	expect(keyHolder.read(testKey)?.value).not.toBe(testValue);
 	expect(keyHolder.isEqual(testKey, testValue)).toBe(true);
-});
-
-
-// Can update a key-value pair
-test('Can update a key-value pair', () => {
-	const keyHolder = new KeyHolder();
-
-	keyHolder.save({ key: testKey, value: testValue });
-	keyHolder.update({ key: testKey, value: 'updated-value' });
-	expect(keyHolder.read(testKey)).toBe('updated-value');
-
-	// try to update a non existant value and pass if it throws an error
-	expect(() => { 
-		keyHolder.update({ key: 'non-existant-key', value: 'updated-value' });
-	}).toThrowError();
-	
 });
 
 
@@ -59,7 +43,18 @@ test('Can read all key-value pairs from the store', () => {
 		{ key: testKey, value: testValue, hashed: false },
 	]});
 
-	expect(keyHolder.readAll()).toEqual({ [testKey]: { value: testValue, hashed: false } });
+	expect(keyHolder.readAll()).toEqual({ [testKey]: { key: testKey, value: testValue, hashed: false } });
+});
+
+
+// Store preventsd overwriting existing values
+test('Store prevents overwriting existing values', () => {
+	const keyHolder = new KeyHolder();
+
+	keyHolder.save({ key: testKey, value: testValue });
+	expect(keyHolder.read(testKey)?.value).toBe(testValue);
+	
+	expect(() => keyHolder.save({ key: testKey, value: testValue })).toThrow();
 });
 
 
@@ -68,10 +63,10 @@ test('Can load a set of key-value pairs into the store', () => {
 	const keyHolder = new KeyHolder();
 
 	keyHolder.saveBulk([
-		{ key: testKey, value: testValue, hashed: false },
+		{ key: testKey, value: testValue, hashed: false }, 
 	]);
 
-	expect(keyHolder.read(testKey)).toBe(testValue);
+	expect(keyHolder.read(testKey)?.value).toBe(testValue);
 });
 
 
@@ -91,7 +86,7 @@ test('Can read from a JSON file', () => {
 	const keyHolder = new KeyHolder();
 
 	keyHolder.saveBulkFromFile(testFile).then(() => {
-		expect(keyHolder.read(testKey)).toBe(testValue);
+		expect(keyHolder.read(testKey)?.value).toBe(testValue);
 	});
 });
 
@@ -101,11 +96,11 @@ test('Can remove a key-value pair from the store', () => {
 		{ key: testKey, value: testValue, hashed: false },
 	]});
 
-	expect(keyHolder.read(testKey)).toBe(testValue);
+	expect(keyHolder.read(testKey)?.value).toBe(testValue);
 
 	keyHolder.remove(testKey);
 
-	expect(keyHolder.read(testKey)).toBe(null);
+	expect(keyHolder.read(testKey)?.value).toBe(undefined);
 });
 
 
@@ -116,13 +111,13 @@ test('Can bulk remove a set of key-value pairs from the store', () => {
 		{ key: `${testKey}-2`, value: `${testValue}-2`, hashed: false },
 	]});
 
-	expect(keyHolder.read(testKey)).toBe(testValue);
-	expect(keyHolder.read(`${testKey}-2`)).toBe(`${testValue}-2`);
+	expect(keyHolder.read(testKey)?.value).toBe(testValue);
+	expect(keyHolder.read(`${testKey}-2`)?.value).toBe(`${testValue}-2`);
 
 	keyHolder.removeBulk([testKey, `${testKey}-2`]);
 
-	expect(keyHolder.read(testKey)).toBe(null);
-	expect(keyHolder.read(`${testKey}-2`)).toBe(null);
+	expect(keyHolder.read(testKey)?.value).toBe(undefined);
+	expect(keyHolder.read(`${testKey}-2`)?.value).toBe(undefined);
 });
 
 
@@ -132,11 +127,11 @@ test('Can clear all pairs from the store', () => {
 		{ key: testKey, value: testValue, hashed: false },
 	]});
 
-	expect(keyHolder.read(testKey)).toBe(testValue);
+	expect(keyHolder.read(testKey)?.value).toBe(testValue);
 
 	keyHolder.clear();
 
-	expect(keyHolder.read(testKey)).toBe(null);
+	expect(keyHolder.read(testKey)?.value).toBe(undefined);
 });
 
 
@@ -179,8 +174,8 @@ test('Can check if key exists with method', () => {
 		{ key: testKey, value: testValue, hashed: false },
 	]});
 
-	expect(keyHolder. exists(testKey)).toBe(true);
-	expect(keyHolder. exists(`${testKey}-2`)).toBe(false);
+	expect(keyHolder.exists(testKey)).toBe(true);
+	expect(keyHolder.exists(`${testKey}-2`)).toBe(false);
 });
 
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,15 +1,15 @@
 export interface IKeyStore {
 
-  read(key: string): string | null
+  read(key: string): TKeyData | null
 
   readAll(): TKeyData[]
 
-  save({ key, value, hashed }: TKeyData): void
+  save(data: TKeyData, settings?: TSaveSettings): void
 
   saveBulk(data: TKeyData[]): Promise<void>
 
   saveBulkFromFile(filePath: string): Promise<unknown>
-
+  
   update({ key, value, hashed }: TKeyData): void
 
   dump(filePath: string): Promise<unknown>
@@ -43,3 +43,7 @@ export type TKeyStoreInit = {
   settings?: TKeyStoreSettings,
   data?: TKeyData[],
 };
+
+export type TSaveSettings = { 
+  overwrite?: boolean,
+}


### PR DESCRIPTION
### Changes
<!-- Describe your commits and what they change. -->
This PR adds the `overwrite` option to save methods with a default of false, this allows for keys to be overwrote if wanted, but puts stronger guards by default otherwise.
  
<!-- If this pull request is related to any issues, please tag them below. -->

  
#### Licensing
<!-- Make sure you check both of these, otherwise your work might not be merged. -->
- [x] I agree to license my work under the repository LICENSE.
